### PR TITLE
Hard-code startup settings for MoFo

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -21,7 +21,9 @@ var loadDefault = function(version) {
   switch (version) {
     case 1:
       return {
-        teams: [],
+        teams: [
+          {name: 'Mozilla Foundation', url: 'https://chat.mozillafoundation.org'}
+        ],
         hideMenuBar: false,
         version: 1
       };

--- a/src/main.js
+++ b/src/main.js
@@ -31,8 +31,8 @@ else {
 }
 
 var config = {};
+var configFile = global['config-file'];
 try {
-  var configFile = global['config-file'];
   config = settings.readFileSync(configFile);
   if (config.version != settings.version) {
     config = settings.upgrade(config);
@@ -41,6 +41,7 @@ try {
 }
 catch (e) {
   config = settings.loadDefault();
+  settings.writeFileSync(configFile, config);
   console.log('Failed to read or upgrade config.json');
 }
 


### PR DESCRIPTION
1. Add MoFo server to default team settings.
2. Write default config on startup if config doesn't exist yet.
